### PR TITLE
fix: lock only when body can scroll

### DIFF
--- a/src/components/vue-modaltor.vue
+++ b/src/components/vue-modaltor.vue
@@ -183,17 +183,24 @@ export default {
         }
       }
     },
+    _hasScrollbar() {
+      return document.body.scrollHeight > (window.innerHeight || document.documentElement.clientHeight)
+    },
     _lockBody() {
-      this.backups.body.height = document.body.style.height
-      this.backups.body.overflow = document.body.style.overflow
-      document.body.style.paddingRight = "15px"
-      document.body.style.height = "100%"
-      document.body.style.overflow = "hidden"
+      if (this._hasScrollbar()) {
+        this.backups.body.height = document.body.style.height
+        this.backups.body.overflow = document.body.style.overflow
+        document.body.style.paddingRight = "15px"
+        document.body.style.height = "100%"
+        document.body.style.overflow = "hidden"
+      }
     },
     _unlockBody() {
-      document.body.style.height = this.backups.body.height
-      document.body.style.overflow = this.backups.body.overflow
-      document.body.style.paddingRight = this.backups.body.paddingRight
+      if (this._hasScrollbar()) {
+        document.body.style.height = this.backups.body.height
+        document.body.style.overflow = this.backups.body.overflow
+        document.body.style.paddingRight = this.backups.body.paddingRight
+      }
     }
   }
 }


### PR DESCRIPTION
only lock body when body element can scroll.
you will see all element moved if body can't scroll because you add padding.
see [reproduction](https://codesandbox.io/s/peaceful-moore-e4mmu?file=/src/App.vue)