### PR TITLE
Fix lifecycle hooks for Vue 3

### DIFF
--- a/src/components/vue-modaltor.vue
+++ b/src/components/vue-modaltor.vue
@@ -121,10 +121,10 @@ export default {
       }
     }
   },
-  beforeDestroy() {
+  beforeUnmount() {
     window.removeEventListener("resize", this.getWindowWidth)
   },
-  destroyed() {
+  unmounted() {
     this.destroyModal()
   },
   mounted() {


### PR DESCRIPTION
## Summary
- update vue-modaltor component to use `beforeUnmount` and `unmounted`

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684909047c788325a3de012c66db8703