### PR TITLE
Update Vue dependencies to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,18 +17,18 @@
   "main": "./dist/modaltor.common.js",
   "dependencies": {
     "core-js": "^3.6.5",
-    "vue": "^2.6.11"
+    "vue": "^3.3.4"
   },
   "devDependencies": {
-    "@vue/cli-plugin-babel": "~4.5.0",
-    "@vue/cli-plugin-eslint": "~4.5.0",
-    "@vue/cli-service": "~4.5.0",
+    "@vue/cli-plugin-babel": "^5.0.8",
+    "@vue/cli-plugin-eslint": "^5.0.8",
+    "@vue/cli-service": "^5.0.8",
     "babel-eslint": "^10.1.0",
     "eslint": "^6.7.2",
     "eslint-plugin-vue": "^6.2.2",
     "node-sass": "7.0.0",
     "sass-loader": "8.0.0",
-    "vue-template-compiler": "^2.6.11"
+    "@vue/compiler-sfc": "^3.3.4"
   },
   "eslintConfig": {
     "root": true,


### PR DESCRIPTION
## Summary
- switch to Vue 3 build tooling
- update @vue/cli-service and related packages
- use @vue/compiler-sfc instead of vue-template-compiler

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build-library` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849090a2e0083258901bf8b09d02553