### PR TITLE
Update to Vue3 bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,18 +17,18 @@
   "main": "./dist/modaltor.common.js",
   "dependencies": {
     "core-js": "^3.6.5",
-    "vue": "^2.6.11"
+    "vue": "^3.2.0"
   },
   "devDependencies": {
-    "@vue/cli-plugin-babel": "~4.5.0",
-    "@vue/cli-plugin-eslint": "~4.5.0",
-    "@vue/cli-service": "~4.5.0",
+    "@vue/cli-plugin-babel": "~5.0.0",
+    "@vue/cli-plugin-eslint": "~5.0.0",
+    "@vue/cli-service": "~5.0.0",
     "babel-eslint": "^10.1.0",
     "eslint": "^6.7.2",
-    "eslint-plugin-vue": "^6.2.2",
+    "eslint-plugin-vue": "^7.0.0",
     "node-sass": "7.0.0",
     "sass-loader": "8.0.0",
-    "vue-template-compiler": "^2.6.11"
+    "@vue/compiler-sfc": "^3.2.0"
   },
   "eslintConfig": {
     "root": true,

--- a/src/components/vue-modaltor.vue
+++ b/src/components/vue-modaltor.vue
@@ -121,10 +121,10 @@ export default {
       }
     }
   },
-  beforeDestroy() {
+  beforeUnmount() {
     window.removeEventListener("resize", this.getWindowWidth)
   },
-  destroyed() {
+  unmounted() {
     this.destroyModal()
   },
   mounted() {

--- a/src/install.js
+++ b/src/install.js
@@ -1,17 +1,13 @@
 import vueModaltor from "./components/vue-modaltor.vue";
 const modalTor = {
-    install(Vue, options) {
-        let component = vueModaltor;
+    install(app, options = {}) {
+        const component = vueModaltor;
         for (let k in options) {
-            // eslint-disable-next-line no-prototype-builtins
-            if (component.props.hasOwnProperty(k)) {
+            if (Object.prototype.hasOwnProperty.call(component.props, k)) {
                 component.props[k].default = options[k];
             }
         }
-        Vue.component("vue-modaltor", component);
+        app.component("vue-modaltor", component);
     }
 };
-if (typeof window !== "undefined" && window.Vue) {
-    window.Vue.use(modalTor);
-}
 export default modalTor;

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,4 @@
-import Vue from 'vue'
+import { createApp } from 'vue'
 import App from './App.vue'
 
-Vue.config.productionTip = false
-
-new Vue({
-  render: h => h(App),
-}).$mount('#app')
+createApp(App).mount('#app')


### PR DESCRIPTION
## Summary
- update Vue to 3 and related tooling
- switch bootstrap code to `createApp`
- adjust plugin install signature for Vue 3
- replace deprecated lifecycle hooks

## Testing
- `yarn build` *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68490916f4708325a849b2b2d8325518